### PR TITLE
Add mutable-content support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v1.1.0
+
+### Added
+
+- Enable support of `mutable-content` for iOS 10+ devices
+
+### Fixed
+
+- Passthrough notifible to message
+
 ## v1.0.1
 
 ### Fixed

--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -50,7 +50,7 @@ class FcmChannel
 
         $response = $this->fcm_client->sendMessage(
             $route_notification_for_fcm,
-            $notification->{$method_name}()
+            $notification->{$method_name}($notifiable)
         );
 
         if ($response->getStatusCode() !== 200) {

--- a/src/FcmClient.php
+++ b/src/FcmClient.php
@@ -50,20 +50,6 @@ class FcmClient
         ]);
     }
 
-    public function so()
-    {
-        [
-            'private_key_id'              => env('FCM_CREDENTIALS_private_key_id', 'da80b3bbceaa554442ad67e6be361a66'),
-            'private_key'                 => env('FCM_CREDENTIALS_private_key', '-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n'),
-            'client_email'                => env('FCM_CREDENTIALS_client_email', 'firebase-adminsdk-mwax6@test.iam.gserviceaccount.com'),
-            'client_id'                   => env('FCM_CREDENTIALS_client_id', '22021520333507180281'),
-            'auth_uri'                    => env('FCM_CREDENTIALS_auth_uri', 'https://accounts.google.com/o/oauth2/auth'),
-            'token_uri'                   => env('FCM_CREDENTIALS_token_uri', 'https://oauth2.googleapis.com/token'),
-            'auth_provider_x509_cert_url' => env('FCM_CREDENTIALS_auth_provider_x509_cert_url', 'https://www.googleapis.com/oauth2/v1/certs'),
-            'client_x509_cert_url'        => env('FCM_CREDENTIALS_client_x509_cert_url', 'https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk-mwax6%40test.iam.gserviceaccount.com'),
-        ];
-    }
-
     /**
      * Unset all empty data from payload.
      *

--- a/src/PlatformSettings/AppleFcmPlatformSettings.php
+++ b/src/PlatformSettings/AppleFcmPlatformSettings.php
@@ -132,6 +132,15 @@ class AppleFcmPlatformSettings implements Arrayable
     protected $launch_image;
 
     /**
+     * Allow to modify payload on iOS 10+ devices.
+     *
+     * @see https://developer.apple.com/documentation/usernotifications/unnotificationserviceextension
+     *
+     * @var bool
+     */
+    protected $mutable_content;
+
+    /**
      * HTTP request headers defined in Apple Push Notification Service.
      * Refer to APNs request headers for supported headers, e.g. "apns-priority": "10".
      *
@@ -293,6 +302,11 @@ class AppleFcmPlatformSettings implements Arrayable
         $this->launch_image = $launch_image;
     }
 
+    public function setMutableContent(bool $mutable_content)
+    {
+        $this->mutable_content = $mutable_content;
+    }
+
     /**
      * Build an array.
      *
@@ -318,6 +332,7 @@ class AppleFcmPlatformSettings implements Arrayable
                 'content-available' => $this->content_available,
                 'category'          => $this->category,
                 'thread-id'         => $this->thread_id,
+                'mutable-content'   => (int) $this->mutable_content,
             ],
         ];
     }

--- a/tests/FcmChannelTest.php
+++ b/tests/FcmChannelTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use AvtoDev\FirebaseNotificationsChannel\FcmClient;
 use AvtoDev\FirebaseNotificationsChannel\FcmChannel;
 use AvtoDev\FirebaseNotificationsChannel\FcmMessage;
@@ -56,7 +57,8 @@ class FcmChannelTest extends AbstractTestCase
     {
         $response = new Response(200, [], \json_encode(['message_id' => 'test']));
         $this->mock_handler->append($response);
-
+        $notification = new class extends Notification implements ShouldQueue {
+        };
         $this->firebase_channel->send($this->getNotifiableMock(), $this->getNotificationMock());
     }
 

--- a/tests/PlatformSettings/AppleFcmPlatformSettingsTest.php
+++ b/tests/PlatformSettings/AppleFcmPlatformSettingsTest.php
@@ -29,6 +29,7 @@ class AppleFcmPlatformSettingsTest extends AbstractPlatformSettingsTest
             ['content_available', 'payload.content-available', 234],
             ['category', 'payload.category', 'category_test'],
             ['thread_id', 'payload.thread-id', 'thread_id_test'],
+            ['mutable_content', 'payload.mutable-content', 1],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No

## Description

### Added

- Enable support of `mutable-content` for iOS 10+ devices

### Fixed

- Passthrough notifible to message

Fixes #5 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/firebase-notifications-laravel/blob/master/CHANGELOG.md) file
