### PR TITLE
Add Laravel 9 support & Update deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
 jobs: # Docs: <https://git.io/JvxXE>
   php:
     name: PHP ${{ matrix.php }}, ${{ matrix.setup }} setup, laravel ${{ matrix.laravel }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -21,15 +21,10 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['7.3', '7.4', '8.0']
-        include:
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '^7.0'
+        php: ['8.0','8.1','8.2']
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 # Action page: <https://github.com/shivammathur/setup-php>
@@ -39,12 +34,12 @@ jobs: # Docs: <https://git.io/JvxXE>
 
       - name: Get Composer Cache Directory # Docs: <https://git.io/JfAKn#php---composer>
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "output_dir=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies # Docs: <https://git.io/JfAKn#php---composer>
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.3
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.output_dir }}
           key: ${{ runner.os }}-composer-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
@@ -73,7 +68,7 @@ jobs: # Docs: <https://git.io/JvxXE>
           XDEBUG_MODE: coverage
         run: composer test-cover
 
-      - uses: codecov/codecov-action@v1 # Docs: <https://github.com/codecov/codecov-action>
+      - uses: codecov/codecov-action@v3 # Docs: <https://github.com/codecov/codecov-action>
         if: matrix.coverage == 'yes'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -83,10 +78,10 @@ jobs: # Docs: <https://git.io/JvxXE>
 
   lint-changelog:
     name: Lint changelog file
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Lint changelog file
         uses: docker://avtodev/markdown-lint:v1 # Action page: <https://github.com/avto-dev/markdown-lint>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Changed
+
+- Minimal require PHP version now is `8.0`
+- Minimal Laravel version now is `9.0`
+- Version of `composer` in docker container updated up to `2.5.3`
+
 ## v2.5.0
 
 ### Removed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM php:7.3-alpine
+FROM php:8.0-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.0.7 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.5.3 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
-    && apk add --no-cache --virtual .build-deps autoconf pkgconf make g++ gcc 1>/dev/null \
+    && apk add --no-cache --virtual .build-deps autoconf linux-headers pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-3.0.0 1>/dev/null \
+    && pecl install xdebug-3.2.0 1>/dev/null \
     && apk del .build-deps \
     && mkdir /src ${COMPOSER_HOME} \
     && ln -s /usr/bin/composer /usr/bin/c \

--- a/composer.json
+++ b/composer.json
@@ -15,21 +15,21 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": "^8.0",
         "ext-json": "*",
         "ext-mbstring": "*",
         "google/apiclient": "^2.2",
-        "guzzlehttp/guzzle": "~6.0 || ~7.0",
-        "illuminate/notifications": "~6.0 || ~7.0 || ~8.0",
-        "illuminate/config": "~6.0 || ~7.0 || ~8.0",
-        "illuminate/contracts": "~6.0 || ~7.0 || ~8.0",
-        "illuminate/support": "~6.0 || ~7.0 || ~8.0"
+        "guzzlehttp/guzzle": "~7.0",
+        "illuminate/notifications": "~9.0",
+        "illuminate/config": "~9.0",
+        "illuminate/contracts": "~9.0",
+        "illuminate/support": "~9.0"
     },
     "require-dev": {
-        "laravel/laravel": "~6.0 || ~7.0 || ~8.0",
-        "mockery/mockery": "^1.0",
-        "phpstan/phpstan": "~0.12.36",
-        "phpunit/phpunit": "^8.5.4 || ^9.3"
+        "laravel/laravel": "~9.0",
+        "mockery/mockery": "^1.5.1",
+        "phpstan/phpstan": "~1.8",
+        "phpunit/phpunit": "~9.6"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,4 +1,5 @@
 parameters:
   level: 'max'
+  checkGenericClassInNonGenericObjectType: false
   paths:
     - src

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,33 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="./tests/bootstrap.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         forceCoversAnnotation="true"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-            <exclude>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <logging>
-        <!--log type="coverage-html" target="./coverage/html"/-->
-        <log type="coverage-xml" target="./coverage/xml"/>
-        <log type="coverage-clover" target="./coverage/clover.xml"/>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="./tests/bootstrap.php" backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" forceCoversAnnotation="true" stopOnFailure="false">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="./coverage/clover.xml"/>
+      <text outputFile="php://stdout" showUncoveredFiles="false"/>
+      <xml outputDirectory="./coverage/xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <!--log type="coverage-html" target="./coverage/html"/-->
+  </logging>
 </phpunit>

--- a/src/FcmChannel.php
+++ b/src/FcmChannel.php
@@ -35,6 +35,10 @@ class FcmChannel
      */
     public function send($notifiable, Notification $notification): void
     {
+        /** @var object $notifiable */
+        if (! \method_exists($notifiable, 'routeNotificationFor')) {
+            return;
+        }
         $route_notification_for_fcm = $notifiable->routeNotificationFor('fcm', $notification);
 
         if (! ($route_notification_for_fcm instanceof FcmNotificationReceiverInterface)) {

--- a/src/PlatformSettings/WebpushFcmPlatformSettings.php
+++ b/src/PlatformSettings/WebpushFcmPlatformSettings.php
@@ -11,7 +11,7 @@ class WebpushFcmPlatformSettings implements Arrayable
     /**
      * HTTP headers defined in webpush protocol. Refer to Webpush protocol for supported headers, e.g. "TTL": "15".
      *
-     * @var array<string, string>
+     * @var array<string, mixed>
      */
     protected $headers;
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -23,7 +23,10 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             ->when(FcmChannel::class)
             ->needs(FcmClient::class)
             ->give(function (Container $app) {
-                $credentials = $this->getCredentials($app->make('config'));
+                /** @var ConfigRepository $config */
+                $config = $app->make(ConfigRepository::class);
+
+                $credentials = $this->getCredentials($config);
 
                 /** @var Google_Client $google_client */
                 $google_client = $app->make(Google_Client::class);
@@ -56,6 +59,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $config_driver = $config->get('services.fcm.driver');
 
         if ($config_driver === 'file') {
+            /** @var string $credentials_path */
             $credentials_path = $config->get('services.fcm.drivers.file.path', '');
 
             if (! \file_exists($credentials_path)) {
@@ -70,6 +74,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             throw new InvalidArgumentException('Fcm driver not set');
         }
 
+        /** @var array<string, integer|string> */
         return $credentials;
     }
 }

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -28,7 +28,7 @@ abstract class AbstractTestCase extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/FcmChannelTest.php
+++ b/tests/FcmChannelTest.php
@@ -31,7 +31,7 @@ class FcmChannelTest extends AbstractTestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/FcmClientTest.php
+++ b/tests/FcmClientTest.php
@@ -23,7 +23,7 @@ class FcmClientTest extends AbstractTestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->firebase_client = $this->app->make(FcmClient::class);
@@ -106,6 +106,6 @@ class FcmClientTest extends AbstractTestCase
         $client = new FcmClient($this->http_client, $endpoint);
         $client->sendMessage(new FcmDeviceReceiver(''), new FcmMessage);
 
-        self::assertEquals($endpoint, $this->mock_handler->getLastRequest()->getUri());
+        $this->assertEquals($endpoint, $this->mock_handler->getLastRequest()->getUri());
     }
 }

--- a/tests/FcmMessageTest.php
+++ b/tests/FcmMessageTest.php
@@ -25,7 +25,7 @@ class FcmMessageTest extends AbstractTestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -47,7 +47,7 @@ class FcmMessageTest extends AbstractTestCase
     /**
      * @return void
      */
-    public function testSetters()
+    public function testSetters(): void
     {
         foreach ($this->dataProvider() as [$property, $value, $path]) {
             $this->fcm_message->{'set' . Str::title($property)}($value);

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -28,7 +28,7 @@ class ServiceProviderTest extends AbstractTestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
## Description

### Changed

- Laravel `9.x` is supported
- Minimal require PHP version now is `8.0`
- Minimal Laravel version now is `8.0`
- Version of `composer` in docker container updated up to `2.5.2`

Fixes #18 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file
